### PR TITLE
fix: await save future completion in TimeseriesServiceNoSqlTest

### DIFF
--- a/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlTest.java
@@ -55,7 +55,7 @@ public class TimeseriesServiceNoSqlTest extends BaseTimeseriesServiceTest {
                 new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(5), new JsonDataEntry("test", "{\"test\":\"testValue\"}")));
 
         DeviceId deviceId = new DeviceId(Uuids.timeBased());
-        tsService.save(tenantId, deviceId, timeseries, ttlInSec);
+        tsService.save(tenantId, deviceId, timeseries, ttlInSec).get(MAX_TIMEOUT, TimeUnit.SECONDS);
 
         List<TsKvEntry> fullList = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("test", 0L,
                 TimeUnit.MINUTES.toMillis(6), 1000, 10, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);


### PR DESCRIPTION
The test was not waiting for the async save operation to complete before
querying the results, causing a race condition where only 4 of 5 entries
were persisted by the time findAll was called.

https://claude.ai/code/session_01CEqcZPxGVc7DPNkgWtbFxJ