### PR TITLE
Remove deprecated SecurityManager and ThreadGroup usage in ThingsBoar…

### DIFF
--- a/common/util/src/main/java/org/thingsboard/common/util/ThingsBoardThreadFactory.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/ThingsBoardThreadFactory.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ThingsBoardThreadFactory implements ThreadFactory {
     public static final String THREAD_TOPIC_SEPARATOR = " | ";
     private static final AtomicInteger poolNumber = new AtomicInteger(1);
-    private final ThreadGroup group;
     private final AtomicInteger threadNumber = new AtomicInteger(1);
     private final String namePrefix;
 
@@ -33,9 +32,6 @@ public class ThingsBoardThreadFactory implements ThreadFactory {
     }
 
     private ThingsBoardThreadFactory(String name) {
-        SecurityManager s = System.getSecurityManager();
-        group = (s != null) ? s.getThreadGroup() :
-                Thread.currentThread().getThreadGroup();
         namePrefix = name + "-" +
                 poolNumber.getAndIncrement() +
                 "-thread-";
@@ -59,7 +55,7 @@ public class ThingsBoardThreadFactory implements ThreadFactory {
 
     @Override
     public Thread newThread(Runnable r) {
-        Thread t = new Thread(group, r,
+        Thread t = new Thread(null, r,
                 namePrefix + threadNumber.getAndIncrement(),
                 0);
         if (t.isDaemon())

--- a/common/util/src/test/java/org/thingsboard/common/util/ThingsBoardThreadFactoryTest.java
+++ b/common/util/src/test/java/org/thingsboard/common/util/ThingsBoardThreadFactoryTest.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.common.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThingsBoardThreadFactoryTest {
+
+    @Test
+    @DisplayName("newThread() should create thread with correct name prefix")
+    void newThreadShouldCreateThreadWithCorrectNamePrefix() {
+        // GIVEN
+        ThingsBoardThreadFactory factory = ThingsBoardThreadFactory.forName("test-pool");
+
+        // WHEN
+        Thread thread = factory.newThread(() -> {});
+
+        // THEN
+        assertThat(thread.getName())
+                .as("Thread name should start with the specified pool name")
+                .startsWith("test-pool-");
+    }
+
+    @Test
+    @DisplayName("newThread() should create non-daemon thread")
+    void newThreadShouldCreateNonDaemonThread() {
+        // GIVEN
+        ThingsBoardThreadFactory factory = ThingsBoardThreadFactory.forName("test");
+
+        // WHEN
+        Thread thread = factory.newThread(() -> {});
+
+        // THEN
+        assertThat(thread.isDaemon())
+                .as("Thread should not be a daemon thread")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("newThread() should create thread with normal priority")
+    void newThreadShouldCreateThreadWithNormalPriority() {
+        // GIVEN
+        ThingsBoardThreadFactory factory = ThingsBoardThreadFactory.forName("test");
+
+        // WHEN
+        Thread thread = factory.newThread(() -> {});
+
+        // THEN
+        assertThat(thread.getPriority())
+                .as("Thread should have normal priority")
+                .isEqualTo(Thread.NORM_PRIORITY);
+    }
+
+    @Test
+    @DisplayName("newThread() should inherit thread group from current thread")
+    void newThreadShouldInheritThreadGroup() {
+        // GIVEN
+        ThingsBoardThreadFactory factory = ThingsBoardThreadFactory.forName("test");
+
+        // WHEN
+        Thread thread = factory.newThread(() -> {});
+
+        // THEN
+        assertThat(thread.getThreadGroup())
+                .as("Thread should have a thread group (inherited from current thread)")
+                .isNotNull();
+    }
+
+    @Test
+    @DisplayName("newThread() should create threads with incrementing numbers")
+    void newThreadShouldCreateThreadsWithIncrementingNumbers() {
+        // GIVEN
+        ThingsBoardThreadFactory factory = ThingsBoardThreadFactory.forName("test");
+
+        // WHEN
+        Thread thread1 = factory.newThread(() -> {});
+        Thread thread2 = factory.newThread(() -> {});
+        Thread thread3 = factory.newThread(() -> {});
+
+        // THEN
+        assertThat(thread1.getName())
+                .as("First thread should have thread number 1")
+                .matches("test-\\d+-thread-1");
+        assertThat(thread2.getName())
+                .as("Second thread should have thread number 2")
+                .matches("test-\\d+-thread-2");
+        assertThat(thread3.getName())
+                .as("Third thread should have thread number 3")
+                .matches("test-\\d+-thread-3");
+    }
+
+    @Test
+    @DisplayName("Different factories should have unique pool numbers")
+    void differentFactoriesShouldHaveUniquePoolNumbers() {
+        // GIVEN & WHEN
+        ThingsBoardThreadFactory factory1 = ThingsBoardThreadFactory.forName("pool-a");
+        ThingsBoardThreadFactory factory2 = ThingsBoardThreadFactory.forName("pool-b");
+        Thread thread1 = factory1.newThread(() -> {});
+        Thread thread2 = factory2.newThread(() -> {});
+
+        // THEN
+        assertThat(thread1.getName())
+                .as("Thread from first factory should have pool-a in name")
+                .startsWith("pool-a-");
+        assertThat(thread2.getName())
+                .as("Thread from second factory should have pool-b in name")
+                .startsWith("pool-b-");
+        assertThat(thread1.getName())
+                .as("Threads from different factories should have different names")
+                .isNotEqualTo(thread2.getName());
+    }
+
+    @Test
+    @DisplayName("updateCurrentThreadName() should append topic to thread name")
+    void updateCurrentThreadNameShouldAppendTopicToThreadName() {
+        // GIVEN
+        String originalName = Thread.currentThread().getName();
+
+        // WHEN
+        ThingsBoardThreadFactory.updateCurrentThreadName("topic-suffix");
+
+        // THEN
+        String updatedName = Thread.currentThread().getName();
+        assertThat(updatedName)
+                .as("Thread name should contain the topic separator and suffix")
+                .contains(ThingsBoardThreadFactory.THREAD_TOPIC_SEPARATOR)
+                .endsWith("topic-suffix");
+
+        // CLEANUP
+        Thread.currentThread().setName(originalName);
+    }
+
+    @Test
+    @DisplayName("updateCurrentThreadName() should replace existing topic suffix")
+    void updateCurrentThreadNameShouldReplaceExistingTopicSuffix() {
+        // GIVEN
+        String originalName = Thread.currentThread().getName();
+        ThingsBoardThreadFactory.updateCurrentThreadName("first-topic");
+
+        // WHEN
+        ThingsBoardThreadFactory.updateCurrentThreadName("second-topic");
+
+        // THEN
+        String updatedName = Thread.currentThread().getName();
+        assertThat(updatedName)
+                .as("Thread name should have the new topic suffix")
+                .endsWith("second-topic")
+                .doesNotContain("first-topic");
+
+        // CLEANUP
+        Thread.currentThread().setName(originalName);
+    }
+
+    @Test
+    @DisplayName("addThreadNamePrefix() should prepend prefix to thread name")
+    void addThreadNamePrefixShouldPrependPrefixToThreadName() {
+        // GIVEN
+        String originalName = Thread.currentThread().getName();
+
+        // WHEN
+        ThingsBoardThreadFactory.addThreadNamePrefix("prefix");
+
+        // THEN
+        String updatedName = Thread.currentThread().getName();
+        assertThat(updatedName)
+                .as("Thread name should start with the prefix")
+                .startsWith("prefix-");
+
+        // CLEANUP
+        Thread.currentThread().setName(originalName);
+    }
+}


### PR DESCRIPTION
…dThreadFactory

System.getSecurityManager() was deprecated in Java 17 and removed in Java 21. ThreadGroup is also deprecated for removal. Replace the SecurityManager-based thread group lookup with null, which causes Thread to inherit the current thread's group automatically — matching the behavior of the modern JDK DefaultThreadFactory.

https://claude.ai/code/session_015DdwXGt4sqcCKkBTjszqw8

## Pull Request description

Put your PR description here instead of this sentence.   

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



